### PR TITLE
Improve test suite for pangram

### DIFF
--- a/exercises/pangram/pangram_test.rb
+++ b/exercises/pangram/pangram_test.rb
@@ -19,6 +19,16 @@ class PangramTest < Minitest::Test
     assert Pangram.is_pangram?(str)
   end
 
+  def test_pangram_with_underscore_character
+    str = 'the quick brown_fox jumps over the lazy dog'
+    assert Pangram.is_pangram?(str)
+  end
+
+  def test_pangram_with_sentence_containing_numbers
+    str = 'the qu1ck br0wn fox jumps over the lazy dog'
+    refute Pangram.is_pangram?(str)
+  end
+
   def test_missing_character_x
     skip
     str = 'a quick movement of the enemy will jeopardize five gunboats'


### PR DESCRIPTION
Some implementations use the "/\w/" regex to match characters and add them to an array and then check that the size of the array is equal to 26. These implementations erroneously pass the current test suite.